### PR TITLE
Add support for existing resume PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 AIHawk's core architecture remains **open source**, allowing developers to inspect and extend the codebase. However, due to copyright considerations, we have removed all third‑party provider plugins from this repository.
 
-For a fully integrated experience, including managed provider connections: check out **[laboro.co](https://laboro.co/)** an AI‑driven job board where the agent **automatically applies to jobs** for you.
+For a fully integrated experience, including managed provider connections: check out **[laboro.co](https://laboro.co/)** an AI-driven job board where the agent **automatically applies to jobs** for you.
 
 
 ---
@@ -23,4 +23,21 @@ AIHawk has been featured by major media outlets for revolutionizing how job seek
 [**The Verge**](https://www.theverge.com/2024/10/10/24266898/ai-is-enabling-job-seekers-to-think-like-spammers)
 [**Vanity Fair**](https://www.vanityfair.it/article/intelligenza-artificiale-candidature-di-lavoro)
 [**404 Media**](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/)
+
+## Setup
+
+1. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Place your configuration files in the `data_folder/` directory:
+   - `secrets.yaml` containing your `llm_api_key`
+   - `work_preferences.yaml`
+   - `plain_text_resume.yaml`
+   - `resume.pdf` *(optional)* if you want to reuse an existing resume
+3. Run the application:
+   ```bash
+   python main.py
+   ```
+   Follow the prompts to generate resumes or cover letters. When `resume.pdf` is present, it will be copied instead of generating a new resume.
 

--- a/data_folder/secrets.yaml
+++ b/data_folder/secrets.yaml
@@ -1,1 +1,1 @@
-llm_api_key: 'sk-11KRr4uuTwpRGfeRTfj1T9BlbkFJjP8QTrswHU1yGruru2FR'
+llm_api_key: REPLACE_WITH_YOUR_KEY

--- a/data_folder_example/secrets.yaml
+++ b/data_folder_example/secrets.yaml
@@ -1,1 +1,1 @@
-llm_api_key: 'sk-11KRr4uuTwpRGfeRTfj1T9BlbkFJjP8QTrswHU1yGruru2FR'
+llm_api_key: REPLACE_WITH_YOUR_KEY

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import base64
 import sys
 from pathlib import Path
 import traceback
+import shutil
 from typing import List, Optional, Tuple, Dict
 
 import click
@@ -21,6 +22,7 @@ from src.utils.constants import (
     PLAIN_TEXT_RESUME_YAML,
     SECRETS_YAML,
     WORK_PREFERENCES_YAML,
+    RESUME_PDF,
 )
 # from ai_hawk.bot_facade import AIHawkBotFacade
 # from ai_hawk.job_manager import AIHawkJobManager
@@ -187,7 +189,7 @@ class FileManager:
     REQUIRED_FILES = [SECRETS_YAML, WORK_PREFERENCES_YAML, PLAIN_TEXT_RESUME_YAML]
 
     @staticmethod
-    def validate_data_folder(app_data_folder: Path) -> Tuple[Path, Path, Path, Path]:
+    def validate_data_folder(app_data_folder: Path) -> Tuple[Path, Path, Path, Path, Optional[Path]]:
         """Validate the existence of the data folder and required files."""
         if not app_data_folder.is_dir():
             raise FileNotFoundError(f"Data folder not found: {app_data_folder}")
@@ -199,20 +201,24 @@ class FileManager:
         output_folder = app_data_folder / "output"
         output_folder.mkdir(exist_ok=True)
 
+        pdf_resume = app_data_folder / RESUME_PDF
         return (
             app_data_folder / SECRETS_YAML,
             app_data_folder / WORK_PREFERENCES_YAML,
             app_data_folder / PLAIN_TEXT_RESUME_YAML,
             output_folder,
+            pdf_resume if pdf_resume.exists() else None,
         )
 
     @staticmethod
-    def get_uploads(plain_text_resume_file: Path) -> Dict[str, Path]:
+    def get_uploads(plain_text_resume_file: Path, resume_pdf_file: Optional[Path] = None) -> Dict[str, Path]:
         """Convert resume file paths to a dictionary."""
         if not plain_text_resume_file.exists():
             raise FileNotFoundError(f"Plain text resume file not found: {plain_text_resume_file}")
 
         uploads = {"plainTextResume": plain_text_resume_file}
+        if resume_pdf_file and resume_pdf_file.exists():
+            uploads["resumePdf"] = resume_pdf_file
 
         return uploads
 
@@ -310,6 +316,12 @@ def create_resume_pdf_job_tailored(parameters: dict, llm_api_key: str):
     """
     try:
         logger.info("Generating a CV based on provided parameters.")
+        existing_pdf = parameters["uploads"].get("resumePdf")
+        if existing_pdf:
+            output_dir = Path(parameters["outputFileDirectory"])
+            shutil.copy(existing_pdf, output_dir / "resume_tailored.pdf")
+            logger.info(f"Using existing resume at: {existing_pdf}")
+            return
 
         # Carica il resume in testo semplice
         with open(parameters["uploads"]["plainTextResume"], "r", encoding="utf-8") as file:
@@ -395,6 +407,12 @@ def create_resume_pdf(parameters: dict, llm_api_key: str):
     """
     try:
         logger.info("Generating a CV based on provided parameters.")
+        existing_pdf = parameters["uploads"].get("resumePdf")
+        if existing_pdf:
+            output_dir = Path(parameters["outputFileDirectory"])
+            shutil.copy(existing_pdf, output_dir / "resume_base.pdf")
+            logger.info(f"Using existing resume at: {existing_pdf}")
+            return
 
         # Load the plain text resume
         with open(parameters["uploads"]["plainTextResume"], "r", encoding="utf-8") as file:
@@ -529,14 +547,14 @@ def main():
     try:
         # Define and validate the data folder
         data_folder = Path("data_folder")
-        secrets_file, config_file, plain_text_resume_file, output_folder = FileManager.validate_data_folder(data_folder)
+        secrets_file, config_file, plain_text_resume_file, output_folder, resume_pdf_file = FileManager.validate_data_folder(data_folder)
 
         # Validate configuration and secrets
         config = ConfigValidator.validate_config(config_file)
         llm_api_key = ConfigValidator.validate_secrets(secrets_file)
 
         # Prepare parameters
-        config["uploads"] = FileManager.get_uploads(plain_text_resume_file)
+        config["uploads"] = FileManager.get_uploads(plain_text_resume_file, resume_pdf_file)
         config["outputFileDirectory"] = output_folder
 
         # Interactive prompt for user to select actions

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ pytest
 pytest-mock
 pytest-cov
 undetected-chromedriver==3.5.5
+inquirer

--- a/src/job_application.py
+++ b/src/job_application.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Dict
+from .job import Job
+
+@dataclass
+class JobApplication:
+    job: Job
+    application: Dict
+    resume_path: str = ""
+    cover_letter_path: str = ""

--- a/src/utils/chrome_utils.py
+++ b/src/utils/chrome_utils.py
@@ -15,7 +15,7 @@ def chrome_browser_options():
     options.add_argument("--disable-dev-shm-usage")
     options.add_argument("--ignore-certificate-errors")
     options.add_argument("--disable-extensions")
-    options.add_argument("--disable-gpu")  # Opzionale, utile in alcuni ambienti
+    options.add_argument("--disable-gpu")  # Optional, useful in some environments
     options.add_argument("window-size=1200x800")
     options.add_argument("--disable-background-timer-throttling")
     options.add_argument("--disable-backgrounding-occluded-windows")
@@ -29,8 +29,8 @@ def chrome_browser_options():
     options.add_argument("--disable-animations")
     options.add_argument("--disable-cache")
     options.add_argument("--incognito")
-    options.add_argument("--allow-file-access-from-files")  # Consente l'accesso ai file locali
-    options.add_argument("--disable-web-security")         # Disabilita la sicurezza web
+    options.add_argument("--allow-file-access-from-files")  # Allow access to local files
+    options.add_argument("--disable-web-security")         # Disable web security
     logger.debug("Using Chrome in incognito mode")
     
     return options
@@ -50,44 +50,44 @@ def init_browser() -> webdriver.Chrome:
 
 def HTML_to_PDF(html_content, driver):
     """
-    Converte una stringa HTML in un PDF e restituisce il PDF come stringa base64.
+    Convert an HTML string to a PDF and return it encoded as base64.
 
-    :param html_content: Stringa contenente il codice HTML da convertire.
-    :param driver: Istanza del WebDriver di Selenium.
-    :return: Stringa base64 del PDF generato.
-    :raises ValueError: Se l'input HTML non è una stringa valida.
-    :raises RuntimeError: Se si verifica un'eccezione nel WebDriver.
+    :param html_content: HTML code to convert.
+    :param driver: Selenium WebDriver instance.
+    :return: Base64 string of the generated PDF.
+    :raises ValueError: If the input HTML is empty or invalid.
+    :raises RuntimeError: If a WebDriver exception occurs.
     """
-    # Validazione del contenuto HTML
+    # Validate HTML content
     if not isinstance(html_content, str) or not html_content.strip():
-        raise ValueError("Il contenuto HTML deve essere una stringa non vuota.")
+        raise ValueError("HTML content must be a non-empty string.")
 
-    # Codifica l'HTML in un URL di tipo data
+    # Encode HTML as a data URL
     encoded_html = urllib.parse.quote(html_content)
     data_url = f"data:text/html;charset=utf-8,{encoded_html}"
 
     try:
         driver.get(data_url)
-        # Attendi che la pagina si carichi completamente
-        time.sleep(2)  # Potrebbe essere necessario aumentare questo tempo per HTML complessi
+        # Wait for the page to fully load
+        time.sleep(2)  # Increase if the HTML is complex
 
-        # Esegue il comando CDP per stampare la pagina in PDF
+        # Execute the CDP command to print the page to PDF
         pdf_base64 = driver.execute_cdp_cmd("Page.printToPDF", {
-            "printBackground": True,          # Includi lo sfondo nella stampa
-            "landscape": False,               # Stampa in verticale (False per ritratto)
-            "paperWidth": 8.27,               # Larghezza del foglio in pollici (A4)
-            "paperHeight": 11.69,             # Altezza del foglio in pollici (A4)
-            "marginTop": 0.8,                  # Margine superiore in pollici (circa 2 cm)
-            "marginBottom": 0.8,               # Margine inferiore in pollici (circa 2 cm)
-            "marginLeft": 0.5,                 # Margine sinistro in pollici (circa 1.27 cm)
-            "marginRight": 0.5,                # Margine destro in pollici (circa 1.27 cm)
-            "displayHeaderFooter": False,      # Non visualizzare intestazioni e piè di pagina
-            "preferCSSPageSize": True,         # Preferire le dimensioni della pagina CSS
-            "generateDocumentOutline": False,  # Non generare un sommario del documento
-            "generateTaggedPDF": False,        # Non generare PDF taggato
-            "transferMode": "ReturnAsBase64"   # Restituire il PDF come stringa base64
+            "printBackground": True,          # Include background graphics
+            "landscape": False,               # Portrait orientation
+            "paperWidth": 8.27,               # Page width in inches (A4)
+            "paperHeight": 11.69,             # Page height in inches (A4)
+            "marginTop": 0.8,                 # Top margin in inches (~2 cm)
+            "marginBottom": 0.8,              # Bottom margin in inches (~2 cm)
+            "marginLeft": 0.5,                # Left margin in inches (~1.27 cm)
+            "marginRight": 0.5,               # Right margin in inches (~1.27 cm)
+            "displayHeaderFooter": False,     # Do not show headers/footers
+            "preferCSSPageSize": True,        # Use CSS page size
+            "generateDocumentOutline": False, # Do not generate document outline
+            "generateTaggedPDF": False,       # Do not generate tagged PDF
+            "transferMode": "ReturnAsBase64"  # Return PDF as base64 string
         })
         return pdf_base64['data']
     except Exception as e:
-        logger.error(f"Si è verificata un'eccezione WebDriver: {e}")
-        raise RuntimeError(f"Si è verificata un'eccezione WebDriver: {e}")
+        logger.error(f"WebDriver exception occurred: {e}")
+        raise RuntimeError(f"WebDriver exception occurred: {e}")

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -8,6 +8,7 @@ DATE_24_HOURS = "24_hours"
 SECRETS_YAML = "secrets.yaml"
 WORK_PREFERENCES_YAML = "work_preferences.yaml"
 PLAIN_TEXT_RESUME_YAML = "plain_text_resume.yaml"
+RESUME_PDF = "resume.pdf"
 
 
 # String constants used in the application


### PR DESCRIPTION
## Summary
- allow loading optional `resume.pdf` from `data_folder`
- skip resume generation if a PDF is provided
- create missing `JobApplication` dataclass
- translate Italian comments in `chrome_utils.py`
- sanitize example secrets and add setup docs
- include `inquirer` dependency and newline fix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc110c214832eb977c6b584785cb3